### PR TITLE
Fix/handle ignored files

### DIFF
--- a/scripts/google_replicate.py
+++ b/scripts/google_replicate.py
@@ -17,7 +17,7 @@ from errors import APIError, UserError
 from settings import PROJECT_ACL, INDEXD, GDC_TOKEN
 import indexd_utils
 
-#logger.basicConfig(level=logger.INFO, format='%(asctime)s %(message)s')
+# logger.basicConfig(level=logger.INFO, format='%(asctime)s %(message)s')
 
 DATA_ENDPT = "https://api.gdc.cancer.gov/data/"
 DEFAULT_CHUNK_SIZE_DOWNLOAD = 1024 * 1024 * 5
@@ -25,6 +25,7 @@ DEFAULT_CHUNK_SIZE_UPLOAD = 1024 * 1024 * 20
 NUM_TRIES = 10
 
 logger = get_logger("GoogleReplication")
+
 
 class DataFlowLog(object):
     def __init__(self, copy_success=False, index_success=False, message=""):
@@ -152,13 +153,19 @@ def exec_google_copy(fi, global_config):
             )
 
             resumable_streaming_copy(fi, client, bucket_name, blob_name, global_config)
-    
+
             if fail_resumable_copy_blob(sess, bucket_name, blob_name, fi):
                 res = delete_object(sess, bucket_name, blob_name)
                 if res.status_code in (200, 204):
-                    logger.info("Successfully delete fail upload object {}".format(fi["id"]))
+                    logger.info(
+                        "Successfully delete fail upload object {}".format(fi["id"])
+                    )
                 else:
-                    logger.info("Can not delete fail uploaded object {}. Satus code {}".format(fi["id"], res.status_code))
+                    logger.info(
+                        "Can not delete fail uploaded object {}. Satus code {}".format(
+                            fi["id"], res.status_code
+                        )
+                    )
             else:
                 logger.info(
                     "Finish streaming {}. Size {} (MB)".format(
@@ -375,7 +382,9 @@ def streaming(
                 if number_upload % 500 == 0:
                     logger.info(
                         "Uploading {}. Size {} (MB). Progress {}".format(
-                            blob_name, total_size*1.0/1000/1000, 100.0 * progress / total_size
+                            blob_name,
+                            total_size * 1.0 / 1000 / 1000,
+                            100.0 * progress / total_size,
                         )
                     )
 

--- a/scripts/google_replicate.py
+++ b/scripts/google_replicate.py
@@ -291,10 +291,13 @@ def _is_ignored_object(fi, IGNORED_FILES):
     """
 
     for element in IGNORED_FILES:
-        if fi["id"]==element["gdc_uuid"] and fi["size"] == element["gcs_object_size"] and fi["md5"]==element["md5sum"]:
+        if (
+            fi["id"] == element["gdc_uuid"]
+            and fi["size"] == element["gcs_object_size"]
+            and fi["md5"] == element["md5sum"]
+        ):
             return True
     return False
-    
 
 
 def resumable_streaming_copy(fi, client, bucket_name, blob_name, global_config):

--- a/scripts/google_replicate.py
+++ b/scripts/google_replicate.py
@@ -122,6 +122,10 @@ def exec_google_copy(fi, global_config):
     Returns:
         DataFlowLog
     """
+    if _is_ignored_object(fi, IGNORED_FILES):
+        logger.info("{} is ignored".format(fi["id"]))
+        return DataFlowLog(message="{} is in the ignored list".format(fi["id"]))
+
     indexd_client = IndexClient(
         INDEXD["host"],
         INDEXD["version"],

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -36,11 +36,9 @@ except Exception as e:
 
 
 IGNORED_FILES = []
-try:
-    with open("/dcf-dataservice/ignored_files_manifest.csv", "rt") as f:
-        csvReader = csv.DictReader(f, ",")
-        for row in csvReader:
-            row["gcs_object_size"] = int(row["gcs_object_size"])
-            IGNORED_FILES.append(row)
-except Exception as e:
-    print("Can not read ignored_files_manifest.csv file. Detail {}".format(e))
+
+with open("/dcf-dataservice/ignored_files_manifest.csv", "rt") as f:
+    csvReader = csv.DictReader(f, ",")
+    for row in csvReader:
+        row["gcs_object_size"] = int(row["gcs_object_size"])
+        IGNORED_FILES.append(row)

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -33,3 +33,14 @@ try:
             PROJECT_ACL[line["project_id"]] = line
 except Exception as e:
     print("Can not read GDC_datasets_access_control.csv file. Detail {}".format(e))
+
+
+IGNORED_FILES = []
+try:
+    with open("/dcf-dataservice/ignored_files_manifest.csv", "rt") as f:
+        csvReader = csv.DictReader(f, ",")
+        for row in csvReader:
+            row["gcs_object_size"] = int(row["gcs_object_size"])
+            IGNORED_FILES.append(row)
+except Exception as e:
+    print("Can not read ignored_files_manifest.csv file. Detail {}".format(e))

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -36,9 +36,11 @@ except Exception as e:
 
 
 IGNORED_FILES = []
-
-with open("/dcf-dataservice/ignored_files_manifest.csv", "rt") as f:
-    csvReader = csv.DictReader(f, ",")
-    for row in csvReader:
-        row["gcs_object_size"] = int(row["gcs_object_size"])
-        IGNORED_FILES.append(row)
+try:
+    with open("/dcf-dataservice/ignored_files_manifest.csv", "rt") as f:
+        csvReader = csv.DictReader(f, ",")
+        for row in csvReader:
+            row["gcs_object_size"] = int(row["gcs_object_size"])
+            IGNORED_FILES.append(row)
+except Exception as e:
+    print("Can not read ignored_files_manifest.csv file. Detail {}".format(e))

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -49,7 +49,7 @@ def get_fileinfo_list_from_s3_manifest(url_manifest, start=None, end=None):
     return get_fileinfo_list_from_csv_manifest("./manifest", start, end)
 
 
-def get_fileinfo_list_from_csv_manifest(manifest_file, start=None, end=None, dem = "\t"):
+def get_fileinfo_list_from_csv_manifest(manifest_file, start=None, end=None, dem="\t"):
     """
     get file info from csv manifest
     """


### PR DESCRIPTION
There are some objects already replicated to google storage as structured urls. Let's ignore them when scanning GDC manifest using provided mapping file. The mapping file contains the map of GDC_uuid to the gs url