### PR TITLE
fix(exception): raise exception if IGNORED_FILES is empty

### DIFF
--- a/scripts/google_replicate.py
+++ b/scripts/google_replicate.py
@@ -473,6 +473,10 @@ def run(thread_num, global_config, job_name, manifest_file, bucket=None):
     """
     start threads and log after they finish
     """
+    if not IGNORED_FILES:
+        raise UserError(
+            "Expecting non-empty IGNORED_FILES. Please check if ignored_files_manifest.csv is configured correctly!!!"
+        )
     tasks, _ = utils.prepare_data(manifest_file, global_config)
 
     manager = Manager()

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -38,7 +38,7 @@ except Exception as e:
 IGNORED_FILES = []
 try:
     with open("/dcf-dataservice/ignored_files_manifest.csv", "rt") as f:
-        csvReader = csv.DictReader(f, ",")
+        csvReader = csv.DictReader(f, delimiter=",")
         for row in csvReader:
             row["gcs_object_size"] = int(row["gcs_object_size"])
             IGNORED_FILES.append(row)


### PR DESCRIPTION
We are expecting the IGNORED_FILES is non-empty list if the ignored_files_manifest.csv is correctly configured.