### PR TITLE
Fix/project acl

### DIFF
--- a/scripts/indexd_utils.py
+++ b/scripts/indexd_utils.py
@@ -1,4 +1,4 @@
-from cdislogging import get_logger
+import logging as logger
 from errors import APIError, UserError
 import os
 import utils
@@ -6,7 +6,7 @@ from settings import PROJECT_ACL
 from urlparse import urlparse
 
 
-logger = get_logger("IndexdUtils")
+logger.basicConfig(level=logger.INFO, format="%(asctime)s %(message)s")
 
 
 NAMESPACE = ""

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,5 +2,5 @@ requests==2.20.0
 google-auth==1.4.1
 google-resumable-media==0.3.1
 google-cloud-storage==1.10.0
--e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
+-e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -22,5 +22,6 @@ try:
         PROJECT_ACL = json.loads(f.read())
 except Exception as e:
     print("Can not read GDC_project_map.json file. Detail {}".format(e))
+    raise e
 
 IGNORED_FILES = "/dcf-dataservice/ignored_files_manifest.csv"

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -22,6 +22,5 @@ try:
         PROJECT_ACL = json.loads(f.read())
 except Exception as e:
     print("Can not read GDC_project_map.json file. Detail {}".format(e))
-    raise e
 
 IGNORED_FILES = "/dcf-dataservice/ignored_files_manifest.csv"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -11,7 +11,7 @@ from errors import UserError
 
 def get_aws_bucket_name(fi, PROJECT_ACL):
     try:
-        project_info = PROJECT_ACL[fi.get("project_id").split("-")[0]]
+        project_info = PROJECT_ACL[fi.get("project_id")]
     except KeyError:
         raise UserError("PROJECT_ACL does not have {} key".format(fi.get("project_id")))
 
@@ -30,7 +30,7 @@ def get_aws_bucket_name(fi, PROJECT_ACL):
 
 def get_google_bucket_name(fi, PROJECT_ACL):
     try:
-        project_info = PROJECT_ACL[fi.get("project_id").split("-")[0]]
+        project_info = PROJECT_ACL[fi.get("project_id")]
     except KeyError:
         raise UserError("PROJECT_ACL does not have {} key".format(fi.get("project_id")))
     return project_info["gs_bucket_prefix"] + (

--- a/tests/test_replicate.py
+++ b/tests/test_replicate.py
@@ -25,7 +25,7 @@ TEST_URL = ["test_url1", "test_url2"]
 
 
 PROJECT_ACL = {
-    "TCGA": {
+    "TCGA-PNQS": {
         "aws_bucket_prefix": "tcga",
         "gs_bucket_prefix": "gdc-tcga-phs000178",
     }
@@ -67,6 +67,7 @@ RECORDS = {}
 def reset_records():
     global RECORDS
     RECORDS = copy.deepcopy(DEFAULT_RECORDS)
+
 
 class MockIndexdClient(object):
 


### PR DESCRIPTION
Description about what this pull request does.

### New Features


### Breaking Changes


### Bug Fixes
Originally, data service used only the first part of the project_id ("program") for mapping to the dcf buckets. However, it does not work if there are multiple projects in the same program. Fix by using the whole project_id ("program-project").

### Improvements


### Dependency updates
Use standard logging

### Deployment changes

