### PR TITLE
Quay rate limit workaround and pin pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt install -y git jq curl bash snapd groff python3-pip zip
 
 RUN curl -O https://bootstrap.pypa.io/get-pip.py
 
-RUN python3 get-pip.py && pip install -I pip<20.3
+RUN python3 get-pip.py 'pip<20.3'
 
 RUN pip3 install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/cdis/python:3.7-slim-buster
+FROM python:3.7-slim-buster
 
 RUN apt update && apt install -y git jq curl bash snapd groff python3-pip zip
 
 RUN curl -O https://bootstrap.pypa.io/get-pip.py
 
-RUN python3 get-pip.py
+RUN python3 get-pip.py && pip install -I pip<20.3
 
 RUN pip3 install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM quay.io/cdis/python:3.7-slim-buster
 
 RUN apt update && apt install -y git jq curl bash snapd groff python3-pip zip
 
@@ -15,7 +15,7 @@ RUN mkdir -p /usr/local/gcloud \
   && /usr/local/gcloud/google-cloud-sdk/install.sh
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
- 
+
 COPY . /dcf-dataservice
 WORKDIR /dcf-dataservice
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM quay.io/cdis/python:3.7-slim-buster
 
 RUN apt update && apt install -y git jq curl bash snapd groff python3-pip zip
 


### PR DESCRIPTION
Issue with new version of pip(>=20.3) where it gets stuck in an infinite loop trying to install some packages.
```
Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/site-packages (from google-auth>=1.0.0->google-cloud-storage==1.6.0->-r requirements.txt (line 7)) (4.5)
Requirement already satisfied: six in /usr/local/lib/python3.7/site-packages (from google-resumable-media==0.3.1->-r requirements.txt (line 6)) (1.15.0)
```
Ticket to permanently fix this [PXP-7254](https://ctds-planx.atlassian.net/browse/PXP-7254). Pinning now for a quick fix. 


### Dependency updates
- pin pip to <20.3

### Deployment changes
- build image to `quay.io/cdis/python:3.7-slim-buster` due to quay rate limiting
