### PR TITLE
fix urllib module

### DIFF
--- a/scripts/aws_replicate.py
+++ b/scripts/aws_replicate.py
@@ -526,7 +526,7 @@ def stream_object_from_gdc_api(fi, target_bucket, global_config):
         chunk = None
         while tries < RETRIES_NUM and not request_success:
             try:
-                req = urllib.request(
+                req = urllib.request.Request(
                     data_endpoint,
                     headers={
                         "X-Auth-Token": GDC_TOKEN,
@@ -536,7 +536,7 @@ def stream_object_from_gdc_api(fi, target_bucket, global_config):
                     },
                 )
 
-                chunk = urllib.urlopen(req).read()
+                chunk = urllib.request.urlopen(req).read()
                 if len(chunk) == chunk_info["end"] - chunk_info["start"] + 1:
                     request_success = True
 


### PR DESCRIPTION
See here for details https://stackoverflow.com/questions/12772190/urllib-module-object-is-not-callable

tldr: Doing this fixed it
```
headers = {
    'X-Auth-Token': token,
    "Range": "bytes={}-{}".format(0, 20),
}

try:
    r = urllib.request.Request(url, headers=headers) // instead of just urllib.request
    chunk = urllib.request.urlopen(r).read()
    print(r)
    print(chunk)
except Exception as e:
    print(e)
```

### Bug Fixes
- Fixed newer version of `urllib` does api calls differently which was breaking the way we called the GDC api