### PR TITLE
Fix apache beam install errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ retry==0.9.2
 google-cloud==0.34.0
 google-resumable-media==0.3.1
 google-cloud-storage==1.6.0
-apache-beam[gcp]==2.16.0
 setuptools==40.3.0
+apache-beam[gcp]==2.16.0
 -e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
 # For the Google script, indexclient source must also be available as a zip
 # file and fed to the script using option "--extra_package" (until package is


### PR DESCRIPTION
Change order of setuptools and apache beam packages

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- Change order of install for apache beam and setuptools packages based on https://stackoverflow.com/questions/61078477/apache-beam-2-19-0-not-running-on-cloud-dataflow-anymore-due-to-could-not-find-a as a solution to error during google replicate job

### Deployment changes

