### PR TITLE
Fix Google dataflow install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ retry==0.9.2
 google-cloud==0.34.0
 google-resumable-media==0.3.1
 google-cloud-storage==1.6.0
-apache-beam[gcp]==2.16.0
-setuptools==40.3.0
+apache-beam[gcp]==2.34.0
+setuptools==59.6.0
 -e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
 # For the Google script, indexclient source must also be available as a zip
 # file and fed to the script using option "--extra_package" (until package is

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-python_dateutil==2.8.0
-requests>=2.20.0<3.0.0
-boto3>=1.9.111
+python_dateutil==2.8.2
+requests>=2.26.0<3.0.0
+boto3==1.20.24
 retry==0.9.2
 google-cloud==0.34.0
-google-resumable-media==0.3.1
-google-cloud-storage==1.6.0
+google-resumable-media==2.1.0
+google-cloud-storage==1.43.0
 apache-beam[gcp]==2.34.0
 setuptools==59.6.0
 -e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,7 @@
-requests==2.20.0
+requests==2.26.0
 retry==0.9.2
-google-auth==1.4.1
-google-resumable-media==0.3.1
-google-cloud-storage==1.10.0
+google-auth==2.3.3
+google-resumable-media==2.1.0
+google-cloud-storage==1.43.0
 -e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from __future__ import print_function
 import setuptools
 
 REQUIRED_PACKAGES = [
-    "python_dateutil==2.8.0",
-    "requests>=2.18.0<3.0.0",
-    "boto3>=1.9.111",
+    "python_dateutil==2.8.2",
+    "requests>=2.26.0<3.0.0",
+    "boto3==1.20.24",
     "google-cloud==0.34.0",
-    "google-resumable-media==0.3.1",
-    "google-cloud-storage==1.6.0",
-    "apache-beam[gcp]==2.16.0",
-    "setuptools==40.3.0",
+    "google-resumable-media==2.1.0",
+    "google-cloud-storage==1.43.0",
+    "apache-beam[gcp]==2.34.0",
+    "setuptools==59.6.0",
 ]
 
 PACKAGE_NAME = "scripts"


### PR DESCRIPTION
Apache-beam does it's own pip install through a setup.py file and requirements.txt file

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Change versions of packages, including apache-beam due to error during pip install from old beam package

### Improvements


### Dependency updates
- python_dateutil==2.8.2
- requests>=2.26.0<3.0.0
- boto3==1.20.24
- google-auth==2.3.3
- google-cloud==0.34.0
- google-resumable-media==2.1.0
- google-cloud-storage==1.43.0
- apache-beam[gcp]==2.34.0
- setuptools==59.6.0

### Deployment changes

