### PR TITLE
Update packages for google replication

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -1,0 +1,13 @@
+name: Build Image and Push to Quay
+
+on: push
+
+jobs:
+  ci:
+    name: Build Image and Push to Quay
+    uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
+    secrets:
+      ECR_AWS_ACCESS_KEY_ID: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+      ECR_AWS_SECRET_ACCESS_KEY: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ RUN mkdir -p /usr/local/gcloud \
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 
-COPY . ./dcf-dataservice
+# COPY . /dcf-dataservice
+COPY . .
 WORKDIR /dcf-dataservice
 
-# RUN  pip3 install -r requirements.txt
-RUN PYTHONPATH=/usr/bin/python pip install -r requirements.txt
+RUN  pip3 install -r requirements.txt
+# RUN PYTHONPATH=/usr/bin/python pip install -r requirements.txt
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM quay.io/cdis/python:3.7-slim-buster
 
 RUN apt-get update && apt-get install -y git jq curl bash snapd groff python3-pip zip
 
-# RUN curl -O https://bootstrap.pypa.io/get-pip.py
-
 RUN pip install --upgrade pip
 RUN pip3 install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,10 @@ RUN mkdir -p /usr/local/gcloud \
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 
-# COPY . /dcf-dataservice
-COPY . .
+COPY . /dcf-dataservice
 WORKDIR /dcf-dataservice
 
-RUN  pip3 install -r requirements.txt
+RUN  pip3 install -r dcf-dataservice/requirements.txt
 # RUN PYTHONPATH=/usr/bin/python pip install -r requirements.txt
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN mkdir -p /usr/local/gcloud \
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 
-WORKDIR /dcf-dataservice
 COPY . /dcf-dataservice
+WORKDIR /dcf-dataservice
 
-RUN  pip3 install -r requirements.txt
+# RUN  pip3 install -r requirements.txt
+RUN PYTHONPATH=/usr/bin/python pip install -r requirements.txt
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/gcloud \
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 
-COPY . /dcf-dataservice
+COPY . ./dcf-dataservice
 WORKDIR /dcf-dataservice
 
 # RUN  pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM quay.io/cdis/python:3.7-slim-buster
 
-RUN apt update && apt install -y git jq curl bash snapd groff python3-pip zip
+RUN apt-get update && apt-get install -y git jq curl bash snapd groff python3-pip zip
 
-RUN curl -O https://bootstrap.pypa.io/get-pip.py
+# RUN curl -O https://bootstrap.pypa.io/get-pip.py
 
-RUN python3 get-pip.py 'pip<20.3'
-
+RUN pip install --upgrade pip
 RUN pip3 install awscli
 
 # Installing gcloud package (includes gsutil)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/cdis/python:3.7-slim-buster
 RUN apt-get update && apt-get install -y git jq curl bash snapd groff python3-pip zip
 
 RUN pip install --upgrade pip
-RUN pip3 install awscli
+RUN pip install awscli
 
 # Installing gcloud package (includes gsutil)
 RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
@@ -16,7 +16,6 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 COPY . /dcf-dataservice
 WORKDIR /dcf-dataservice
 
-RUN  pip3 install -r dcf-dataservice/requirements.txt
-# RUN PYTHONPATH=/usr/bin/python pip install -r requirements.txt
+RUN pip install -r dcf-dataservice/requirements.txt
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 COPY . /dcf-dataservice
 WORKDIR /dcf-dataservice
 
-RUN pip install -r dcf-dataservice/requirements.txt
+RUN pip install -r requirements.txt
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN mkdir -p /usr/local/gcloud \
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 
-COPY . /dcf-dataservice
 WORKDIR /dcf-dataservice
+COPY . /dcf-dataservice
 
 RUN  pip3 install -r requirements.txt
 

--- a/dataflow_pipeline.py
+++ b/dataflow_pipeline.py
@@ -102,7 +102,8 @@ def run(argv=None):
             print("Either log bucket or release params is missing")
             return
 
-    pipeline_options = PipelineOptions(pipeline_args)
+    pipeline_options = PipelineOptions(pipeline_args, region="us-central1")
+
     pipeline_options.view_as(SetupOptions).save_main_session = True
 
     p = beam.Pipeline(options=pipeline_options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-cloud-core==1.*
 google-resumable-media==2.3.2
 google-cloud-storage==2.*
 httplib2==0.20.*
-pyparsing==2.4.2
+pyparsing>=2.4.2
 apache-beam[gcp]==2.40.0
 pyyaml==5.4
 pyarrow==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3>=1.9.111<2.0.0
 retry<=0.9.2
 google-auth==2.*
 google-cloud==0.34.0
-google-cloud-core==2.*
+google-cloud-core==2.3.*
 google-resumable-media==2.3.2
 google-cloud-storage==2.*
 httplib2==0.20.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ retry<=0.9.2
 google-auth==2.*
 google-cloud==0.34.0
 google-resumable-media==0.4.1
-google-cloud-storage==1.6.0
+google-cloud-storage==2.*
 httplib2==0.20.*
 pyparsing==2.4.2
 apache-beam[gcp]==2.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ boto3>=1.9.111<2.0.0
 retry<=0.9.2
 google-auth==2.*
 google-cloud==0.34.0
+google-cloud-core==2.*
 google-resumable-media==2.3.2
 google-cloud-storage==2.*
 httplib2==0.20.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python_dateutil==2.8.0
 requests==2.27.1
 boto3>=1.9.111<2.0.0
 retry<=0.9.2
-google-auth==2.*
+google-auth>=1.24.0
 google-cloud==0.34.0
 google-cloud-core==1.*
 google-resumable-media==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ google-resumable-media==2.3.2
 google-cloud-storage==2.*
 httplib2==0.20.*
 pyparsing>=2.4.2
-apache-beam[gcp]==2.40.0
+apache-beam[gcp]==2.*
 pyyaml==5.4
 pyarrow==0.15.1
 setuptools==41.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3>=1.9.111<2.0.0
 retry<=0.9.2
 google-auth==2.*
 google-cloud==0.34.0
-google-cloud-core==2.3.*
+google-cloud-core==1.*
 google-resumable-media==2.3.2
 google-cloud-storage==2.*
 httplib2==0.20.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,6 @@ apache-beam[gcp]==2.40.0
 pyyaml==5.4
 pyarrow==0.15.1
 setuptools==41.4.0
--e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
--e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
-# For the Google script, indexclient source must also be available as a zip
-# file and fed to the script using option "--extra_package" (until package is
-# made available on pypi)
--e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
+cdisloggin==1.1.1
+cdiserrors==1.0.0
+indexclient==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3>=1.9.111<2.0.0
 retry<=0.9.2
 google-auth==2.*
 google-cloud==0.34.0
-google-resumable-media==0.4.1
+google-resumable-media==2.3.2
 google-cloud-storage==2.*
 httplib2==0.20.*
 pyparsing==2.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ apache-beam[gcp]==2.40.0
 pyyaml==5.4
 pyarrow==0.15.1
 setuptools==41.4.0
-cdisloggin==1.1.1
+cdislogging==1.1.1
 cdiserrors==1.0.0
 indexclient==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ python_dateutil==2.8.0
 requests==2.27.1
 boto3>=1.9.111<2.0.0
 retry<=0.9.2
-google-auth==2.9.1
+google-auth==2.*
 google-cloud==0.34.0
 google-resumable-media==0.4.1
 google-cloud-storage==1.6.0
-httplib2==0.19.0
+httplib2==0.20.*
 pyparsing==2.4.2
 apache-beam[gcp]==2.40.0
 pyyaml==5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-resumable-media==0.4.1
 google-cloud-storage==1.6.0
 httplib2==0.19.0
 pyparsing==2.4.2
-apache-beam[gcp]==2.16.0
+apache-beam[gcp]==2.40.0
 pyyaml==5.4
 pyarrow==0.15.1
 setuptools==41.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python_dateutil==2.8.0
 requests==2.27.1
 boto3>=1.9.111<2.0.0
 retry<=0.9.2
-google-auth==1.6.3
+google-auth==2.9.1
 google-cloud==0.34.0
 google-resumable-media==0.4.1
 google-cloud-storage==1.6.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,8 @@
 requests==2.27.1
 retry<=0.9.2
-google-auth==1.6.3
-google-resumable-media==0.4.1
-google-cloud-storage==1.6.0
+google-auth>=1.24.0
+google-resumable-media==2.3.2
+google-cloud-storage==2.*
 urllib3==1.26.5
--e git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
--e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
+cdislogging==1.1.1
+cdiserrors==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,17 @@ import setuptools
 # More details here: https://cloud.google.com/dataflow/docs/concepts/sdk-worker-dependencies#python-3.7.12
 REQUIRED_PACKAGES = [
     "python_dateutil==2.8.0",
-    "requests==2.22.0",
+    "requests==2.27.0",
     "boto3>=1.9.111<2.0.0",
     "retry<=0.9.2",
-    "google-auth==1.6.3",
+    "google-auth==1.24.3",
     "google-cloud==0.34.0",
-    "google-resumable-media==0.4.1",
-    "google-cloud-storage==1.6.0",
-    "httplib2==0.12.0",
+    "google-resumable-media==2.3.2",
+    "google-cloud-storage==2.*",
+    "httplib2==0.20.*",
     "pyparsing==2.4.2",
-    "apache-beam[gcp]==2.16.0",
-    "urllib3==1.25.6",
+    "apache-beam[gcp]==2.*",
+    "urllib3==1.26.5",
     "setuptools==41.4.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ import setuptools
 # More details here: https://cloud.google.com/dataflow/docs/concepts/sdk-worker-dependencies#python-3.7.12
 REQUIRED_PACKAGES = [
     "python_dateutil==2.8.0",
-    "requests==2.27.0",
+    "requests==2.27.1",
     "boto3>=1.9.111<2.0.0",
     "retry<=0.9.2",
-    "google-auth==1.24.3",
+    "google-auth>=1.24.0",
     "google-cloud==0.34.0",
     "google-resumable-media==2.3.2",
     "google-cloud-storage==2.*",
     "httplib2==0.20.*",
-    "pyparsing==2.4.2",
+    "pyparsing>=2.4.2",
     "apache-beam[gcp]==2.*",
     "urllib3==1.26.5",
     "setuptools==41.4.0",


### PR DESCRIPTION
Google replication script stopped working after DR32 and wouldn't get past startup. Needed to update the version for Apache Beam (used for Datadflow), which required many subsequent package updates.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Updated packages for google replication script
- Added GitHub workflow for building images
- Changes to Docker file for pip install/update

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- google-auth
- requests
- urllib3
- google-cloud-core
- google-resumable-media
- google-cloud-storage
- httplib2
- pyparsing
- apache-beam[gcp]
- cdislogging
- cdiserrors
- indexclient

### Deployment changes

