### PR TITLE
PXP-9416: Prevent slack webhook from exiting out

### DIFF
--- a/replicate.py
+++ b/replicate.py
@@ -9,6 +9,10 @@ import scripts.validate as validate
 from scripts.settings import SLACK_URL
 from scripts.deletion import delete_objects_from_cloud_resources
 
+from cdislogging import get_logger
+
+logger = get_logger("DCFReplicate")
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
@@ -64,7 +68,7 @@ if __name__ == "__main__":
     try:
         req = requests.post(SLACK_URL, json={"text": f"Starting {args.action}"})
     except requests.exceptions.RequestException as e:
-        raise SystemExit(e)
+        logger.error("The slack hook has an encountered an error: Detail {}".format(e))
 
     if args.action == "aws_replicate" or args.action == "indexing":
         job_name = "copying" if args.action == "aws_replicate" else "indexing"
@@ -104,4 +108,4 @@ if __name__ == "__main__":
     try:
         req = requests.post(SLACK_URL, json={"text": f"Completed {args.action}"})
     except requests.exceptions.RequestException as e:
-        raise SystemExit(e)
+        logger.error("The slack hook has an encountered an error: Detail {}".format(e))

--- a/replicate.py
+++ b/replicate.py
@@ -1,14 +1,13 @@
 import timeit
 import argparse
 import json
-import requests
 
 import scripts.aws_replicate as aws_replicate
 import scripts.google_replicate as google_replicate
 import scripts.validate as validate
 from scripts.settings import SLACK_URL
 from scripts.deletion import delete_objects_from_cloud_resources
-
+from slack_sdk.webhook import WebhookClient
 from cdislogging import get_logger
 
 logger = get_logger("DCFReplicate")
@@ -64,10 +63,11 @@ def parse_arguments():
 if __name__ == "__main__":
     start = timeit.default_timer()
     args = parse_arguments()
+    webhook = WebhookClient(SLACK_URL)
 
     try:
-        req = requests.post(SLACK_URL, json={"text": f"Starting {args.action}"})
-    except requests.exceptions.RequestException as e:
+        response = webhook.send(text=f"Starting {args.action}")
+    except Exception as e:
         logger.error("The slack hook has an encountered an error: Detail {}".format(e))
 
     if args.action == "aws_replicate" or args.action == "indexing":
@@ -106,6 +106,6 @@ if __name__ == "__main__":
     print("Total time: {} seconds".format(end - start))
 
     try:
-        req = requests.post(SLACK_URL, json={"text": f"Completed {args.action}"})
-    except requests.exceptions.RequestException as e:
+        response = webhook.send(text=f"Completed {args.action}")
+    except Exception as e:
         logger.error("The slack hook has an encountered an error: Detail {}".format(e))

--- a/replicate.py
+++ b/replicate.py
@@ -66,8 +66,10 @@ if __name__ == "__main__":
     webhook = WebhookClient(SLACK_URL)
 
     try:
-        response = webhook.send(text=f"Starting {args.action}")
-    except Exception as e:
+        slack_call = webhook.send(text=f"Starting {args.action}")
+        assert slack_call.status_code == 200
+        assert slack_call.body == "ok"
+    except AssertionError as e:
         logger.error("The slack hook has an encountered an error: Detail {}".format(e))
 
     if args.action == "aws_replicate" or args.action == "indexing":
@@ -106,6 +108,8 @@ if __name__ == "__main__":
     print("Total time: {} seconds".format(end - start))
 
     try:
-        response = webhook.send(text=f"Completed {args.action}")
-    except Exception as e:
+        slack_call = webhook.send(text=f"Completed {args.action}")
+        assert slack_call.status_code == 200
+        assert slack_call.body == "ok"
+    except AssertionError as e:
         logger.error("The slack hook has an encountered an error: Detail {}".format(e))

--- a/replicate.py
+++ b/replicate.py
@@ -68,9 +68,8 @@ if __name__ == "__main__":
     try:
         slack_call = webhook.send(text=f"Starting {args.action}")
         assert slack_call.status_code == 200
-        assert slack_call.body == "ok"
     except AssertionError as e:
-        logger.error("The slack hook has an encountered an error: Detail {}".format(e))
+        logger.error("The slack hook has encountered an error: Detail {}".format(e))
 
     if args.action == "aws_replicate" or args.action == "indexing":
         job_name = "copying" if args.action == "aws_replicate" else "indexing"
@@ -110,6 +109,5 @@ if __name__ == "__main__":
     try:
         slack_call = webhook.send(text=f"Completed {args.action}")
         assert slack_call.status_code == 200
-        assert slack_call.body == "ok"
     except AssertionError as e:
-        logger.error("The slack hook has an encountered an error: Detail {}".format(e))
+        logger.error("The slack hook has encountered an error: Detail {}".format(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ apache-beam[gcp]==2.*
 pyyaml==5.4
 pyarrow==0.15.1
 setuptools==41.4.0
+slack-sdk==3.19.3
 cdislogging==1.1.1
 cdiserrors==1.0.0
 indexclient==2.1.0


### PR DESCRIPTION
Replace system exit with log in the event of an error
Use slack sdk for webhook calls, could potentially build out more elaborate slack notifications in the future

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented error log, over system exit on webhook fail

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- slack-sdk added

### Deployment changes

