### PR TITLE
PXP-10411: Fix misnamed project

### DIFF
--- a/scripts/aws_replicate.py
+++ b/scripts/aws_replicate.py
@@ -158,6 +158,7 @@ def build_object_dataset_aws(project_acl, logger, awsbucket=None):
             continue
 
         # REMINDER: if changing things here, change in get_reversed_acl_bucket_name fnc and scripts/utils:get_aws_bucket_name as well.
+        # Change way this is hardcoded
         for label in ["2-open", "controlled"]:
             if (
                 bucket_info["aws_bucket_prefix"] in POSTFIX_1_EXCEPTION

--- a/scripts/aws_replicate.py
+++ b/scripts/aws_replicate.py
@@ -157,7 +157,7 @@ def build_object_dataset_aws(project_acl, logger, awsbucket=None):
             target_bucket_names.add("target-controlled")
             continue
 
-        # REMINDER: if changing things here, change in get_reversed_acl_bucket_name fnc and scripts/utils:get_aws_bucket_name as well.
+        # REMINDER: if changing things here, change in get_aws_reversed_acl_bucket_name fnc and scripts/utils:get_aws_bucket_name as well.
         # Change way this is hardcoded
         for label in ["2-open", "controlled"]:
             if (
@@ -351,7 +351,7 @@ def exec_aws_copy(lock, quick_test, jobinfo):
         if is_changed_acl_object(fi, jobinfo.copied_objects, target_bucket):
             logger.info("acl object is changed. Move object to the right bucket")
             cmd = 'aws s3 mv "s3://{}/{}" "s3://{}/{}" --acl bucket-owner-full-control'.format(
-                get_reversed_acl_bucket_name(target_bucket),
+                utils.get_aws_reversed_acl_bucket_name(target_bucket),
                 object_key,
                 target_bucket,
                 object_key,
@@ -763,49 +763,15 @@ def validate_uploaded_data(
     return True
 
 
-def get_reversed_acl_bucket_name(target_bucket):
-    """
-    Get reversed acl bucket name
-    """
-    if "target" in target_bucket:
-        if "open" in target_bucket:
-            return "target-controlled"
-        else:
-            return "gdc-target-phs000218-2-open"
-
-    if "tcga" in target_bucket:
-        if "open" in target_bucket:
-            return target_bucket[:-4] + "controlled"
-        else:
-            return target_bucket[:-10] + "open"
-
-    if "controlled" in target_bucket:
-        if "-2-controlled" in target_bucket:
-            target_bucket = target_bucket.replace("-2-controlled", "")
-        else:
-            target_bucket = target_bucket.replace("-controlled", "")
-        if target_bucket in POSTFIX_1_EXCEPTION:
-            return target_bucket + "-open"
-        else:
-            return target_bucket + "-2-open"
-    elif "open" in target_bucket:
-        if "-2-open" in target_bucket:
-            target_bucket = target_bucket.replace("-2-open", "")
-        else:
-            target_bucket = target_bucket.replace("-open", "")
-        if target_bucket in POSTFIX_2_EXCEPTION:
-            return target_bucket + "-2-controlled"
-        else:
-            return target_bucket + "-controlled"
-
-
 def is_changed_acl_object(fi, copied_objects, target_bucket):
     """
     check if the object has acl changed or not
     """
 
     object_path = "{}/{}/{}".format(
-        get_reversed_acl_bucket_name(target_bucket), fi.get("id"), fi.get("file_name")
+        utils.get_aws_reversed_acl_bucket_name(target_bucket),
+        fi.get("id"),
+        fi.get("file_name"),
     )
     if object_path in copied_objects:
         return True

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -72,6 +72,64 @@ def get_google_bucket_name(fi, PROJECT_ACL):
     )
 
 
+def flip_bucket_accounts(aws_bucket_name):
+    """
+    flip bucket name from prod account to open account
+
+    ex:
+        aws_bucket_name: bucket-open
+        return: bucket-2-open
+
+        aws_bucket_name: bucket1-2-controlled
+        return: bucket1-controlled
+    """
+
+    if "-2-controlled" in aws_bucket_name:
+        return aws_bucket_name[:-12] + "controlled"
+    elif "-controlled" in aws_bucket_name:
+        return aws_bucket_name[:-10] + "2-controlled"
+    elif "-2-open" in aws_bucket_name:
+        return aws_bucket_name[:-6] + "open"
+    elif "-open" in aws_bucket_name:
+        return aws_bucket_name[:-4] + "2-open"
+
+
+def get_aws_reversed_acl_bucket_name(target_bucket):
+    """
+    Get reversed acl bucket name
+    """
+    if "target" in target_bucket:
+        if "open" in target_bucket:
+            return "target-controlled"
+        else:
+            return "gdc-target-phs000218-2-open"
+
+    if "tcga" in target_bucket:
+        if "open" in target_bucket:
+            return target_bucket[:-4] + "controlled"
+        else:
+            return target_bucket[:-10] + "open"
+
+    if "controlled" in target_bucket:
+        if "-2-controlled" in target_bucket:
+            target_bucket = target_bucket.replace("-2-controlled", "")
+        else:
+            target_bucket = target_bucket.replace("-controlled", "")
+        if target_bucket in POSTFIX_1_EXCEPTION:
+            return target_bucket + "-open"
+        else:
+            return target_bucket + "-2-open"
+    elif "open" in target_bucket:
+        if "-2-open" in target_bucket:
+            target_bucket = target_bucket.replace("-2-open", "")
+        else:
+            target_bucket = target_bucket.replace("-open", "")
+        if target_bucket in POSTFIX_2_EXCEPTION:
+            return target_bucket + "-2-controlled"
+        else:
+            return target_bucket + "-controlled"
+
+
 def get_fileinfo_list_from_s3_manifest(url_manifest, start=None, end=None):
     """
     Get the manifest from s3
@@ -356,25 +414,3 @@ def get_indexd_records():
         results[doc.did] = doc.urls
 
     return results
-
-
-def flip_bucket_accounts(aws_bucket_name):
-    """
-    flip bucket name from prod account to open account
-
-    ex:
-        aws_bucket_name: bucket-open
-        return: bucket-2-open
-
-        aws_bucket_name: bucket1-2-controlled
-        return: bucket1-controlled
-    """
-
-    if "-2-controlled" in aws_bucket_name:
-        return aws_bucket_name[:-12] + "controlled"
-    elif "-2-open" in aws_bucket_name:
-        return aws_bucket_name[:-6] + "open"
-    elif "-controlled" in aws_bucket_name:
-        return aws_bucket_name[:-10] + "2-controlled"
-    elif "-open" in aws_bucket_name:
-        return aws_bucket_name[:-4] + "2-open"

--- a/tests/test_replicate.py
+++ b/tests/test_replicate.py
@@ -475,75 +475,61 @@ def test_update_url_with_new_url2(reset_records):
     ]
 
 
-def test_get_reversed_acl_bucket_name():
+def test_get_aws_reversed_acl_bucket_name():
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
-            "gdc-target-phs000218-2-open"
-        )
+        utils.get_aws_reversed_acl_bucket_name("gdc-target-phs000218-2-open")
         == "target-controlled"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("target-controlled")
+        utils.get_aws_reversed_acl_bucket_name("target-controlled")
         == "gdc-target-phs000218-2-open"
     )
+    assert utils.get_aws_reversed_acl_bucket_name("tcga-2-open") == "tcga-2-controlled"
+    assert utils.get_aws_reversed_acl_bucket_name("tcga-2-controlled") == "tcga-2-open"
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("tcga-2-open")
-        == "tcga-2-controlled"
-    )
-    assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("tcga-2-controlled")
-        == "tcga-2-open"
-    )
-    assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("gdc-ccle-controlled")
+        utils.get_aws_reversed_acl_bucket_name("gdc-ccle-controlled")
         == "gdc-ccle-2-open"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("gdc-ccle-2-open")
+        utils.get_aws_reversed_acl_bucket_name("gdc-ccle-2-open")
         == "gdc-ccle-controlled"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("gdc-cgci-phs000235-2-open")
+        utils.get_aws_reversed_acl_bucket_name("gdc-cgci-phs000235-2-open")
         == "gdc-cgci-phs000235-2-controlled"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
-            "gdc-cgci-phs000235-2-controlled"
-        )
+        utils.get_aws_reversed_acl_bucket_name("gdc-cgci-phs000235-2-controlled")
         == "gdc-cgci-phs000235-2-open"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
+        utils.get_aws_reversed_acl_bucket_name(
             "gdc-beataml1-cohort-phs001657-2-controlled"
         )
         == "gdc-beataml1-cohort-phs001657-2-open"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
-            "gdc-beataml1-cohort-phs001657-2-open"
-        )
+        utils.get_aws_reversed_acl_bucket_name("gdc-beataml1-cohort-phs001657-2-open")
         == "gdc-beataml1-cohort-phs001657-2-controlled"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
+        utils.get_aws_reversed_acl_bucket_name(
             "gdc-organoid-pancreatic-phs001611-2-controlled"
         )
         == "gdc-organoid-pancreatic-phs001611-2-open"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
+        utils.get_aws_reversed_acl_bucket_name(
             "gdc-organoid-pancreatic-phs001611-2-open"
         )
         == "gdc-organoid-pancreatic-phs001611-2-controlled"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name("gdc-cmi-mbc-phs001709-open")
+        utils.get_aws_reversed_acl_bucket_name("gdc-cmi-mbc-phs001709-open")
         == "gdc-cmi-mbc-phs001709-controlled"
     )
     assert (
-        scripts.aws_replicate.get_reversed_acl_bucket_name(
-            "gdc-cmi-mbc-phs001709-controlled"
-        )
+        utils.get_aws_reversed_acl_bucket_name("gdc-cmi-mbc-phs001709-controlled")
         == "gdc-cmi-mbc-phs001709-open"
     )
 


### PR DESCRIPTION
Changes for visibility on the appropriate code to update when changing project-naming functions.
Project (bucket) name-configuration changes all moved to utils file

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

